### PR TITLE
Consistent de-anonymization of multi-valued placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' blob:; worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests;">    <title>Anonymization</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' blob:; worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests;">    <title>Anonymization</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/Anon.vue
+++ b/src/components/Anon.vue
@@ -475,7 +475,7 @@ import * as pdfjsLib from 'pdfjs-dist';
 import mammoth from 'mammoth';
 import modelCache from '../utils/modelCache.js';
 
-import * as pdfjsWorker from '../assets/pdf.worker.min.mjs';
+// import * as pdfjsWorker from '../assets/pdf.worker.min.mjs';
 
 // Heroicons imports
 import { 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import daisyui from 'daisyui'; // Add this line
+
 export default {
   content: [
     "./index.html",
@@ -8,10 +10,11 @@ export default {
     extend: {},
   },
   plugins: [
-    require('daisyui'),
+    daisyui, // Change 'require('daisyui')' to 'daisyui'
   ],
   daisyui: {
     themes: ["light", "dark"],
   },
 }
+
 


### PR DESCRIPTION
This (completely vibe coded) modification of Anon.vue introduces per-word appendices for multi-valued placeholders to ensure consistent de-anonymization without the multiple bug. See the following example:

<img width="1122" height="680" alt="Bildschirmfoto 2025-08-22 um 23 18 18" src="https://github.com/user-attachments/assets/03e840c2-8691-430d-bb44-a1f00061ceb4" />

<img width="1125" height="679" alt="Bildschirmfoto 2025-08-22 um 23 18 39" src="https://github.com/user-attachments/assets/f93399e5-818a-4f12-b9cc-c77edba7df27" />
